### PR TITLE
Fixed footnote turning into a list item

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ A Jekyll plug-in for embedding SoundCloud sounds in your Liquid templates.
   * mini *
   * artwork *
   
-* Requires a paid SoundCloud tier
+*Requires a paid SoundCloud tier


### PR DESCRIPTION
Last line the footnote * was considered another list item in markdown. Without the space it works as intended.